### PR TITLE
feat: add dynamic component injector for shared HTML/CSS/JS

### DIFF
--- a/features/shared/components/header/header.css
+++ b/features/shared/components/header/header.css
@@ -1,0 +1,67 @@
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: 'Montserrat', sans-serif;
+}
+
+/* Intro Section */
+.header-intro {
+    background-color: black;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+}
+
+.header-tagline {
+    padding: 16px 0;
+    font-size: 12px;
+    font-weight: 500;
+    color: white;
+}
+
+/* Logo */
+.header-logo {
+    margin: 0;
+}
+
+.header-logo-img {
+    width: 100px;
+    transform: scale(1.5);
+    padding-right: 10px;
+}
+
+/* Navigation */
+.header-nav {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.header-nav-list {
+    display: flex;
+    gap: 48px;
+    margin: 20px 0;
+    padding: 0;
+    list-style: none;
+}
+
+.header-link {
+    color: #232323;
+    text-decoration: none;
+    transition: all 100ms ease-in-out;
+}
+
+.header-link:hover {
+    color: #26ab7b;
+    border-bottom: 3px solid #26ab7b;
+    padding-bottom: 4px;
+}
+
+.header-link.active {
+    color: #232323;
+    border-bottom: 3px solid #26ab7b;
+    padding-bottom: 4px;
+}

--- a/features/shared/components/header/header.html
+++ b/features/shared/components/header/header.html
@@ -1,0 +1,28 @@
+<header class="header">
+    <div class="header-intro">
+        <p class="header-tagline">
+            The PREMIER online television network organization of De La Salle
+            University - Manila.
+        </p>
+    </div>
+
+    <figure class="header-logo">
+        <img
+                class="header-logo-img"
+                src="../../../../assets/ARCH__logo.svg"
+                alt="ARCH Logo"
+        />
+    </figure>
+
+    <nav class="header-nav">
+        <ul class="header-nav-list">
+            <li><a href="#" class="header-link" data-name="home">Home</a></li>
+            <li><a href="#" class="header-link" data-name="channels">Channels</a></li>
+            <li><a href="#" class="header-link" data-name="art">Art</a></li>
+            <li><a href="#" class="header-link" data-name="talent">Talent</a></li>
+            <li><a href="#" class="header-link" data-name="about">About Us</a></li>
+            <li><a href="#" class="header-link" data-name="contact">Contact Us</a></li>
+        </ul>
+    </nav>
+</header>
+

--- a/features/shared/components/header/header.js
+++ b/features/shared/components/header/header.js
@@ -1,0 +1,23 @@
+function init_header() {
+    const pathParts = window.location.pathname.split("/");
+    const featuresIndex = pathParts.indexOf("features");
+    const currentPage = featuresIndex !== -1 ? pathParts[featuresIndex + 1] : "home";
+
+    console.log(currentPage);
+
+    const links = document.querySelectorAll(".header .header-link");
+    let matched = false;
+
+    links.forEach(link => {
+        const name = link.dataset.name;
+
+        const isActive = name === currentPage;
+        link.classList.toggle("active", isActive);
+        if (isActive) matched = true;
+    });
+
+    if (!matched) {
+        const homeLink = document.querySelector('.header .header-link[data-name="home"]');
+        if (homeLink) homeLink.classList.add("active");
+    }
+}

--- a/features/shared/scripts/injector.js
+++ b/features/shared/scripts/injector.js
@@ -1,0 +1,71 @@
+/**
+ * Dynamically injects shared HTML components (and their optional CSS/JS files)
+ * into the current page based on `<div id="...">` placeholders.
+ *
+ * Each component is represented by a folder whose name matches the <div> ID.
+ * If a matching folder is found under the specified base path, the injector:
+ *   1. Loads `{id}.html` and injects it into the corresponding <div>.
+ *   2. Optionally loads `{id}.css` into <head> if the file exists.
+ *   3. Optionally loads `{id}.js` into <body> if the file exists.
+ *
+ * This pattern reduces repetitive boilerplate for shared UI parts
+ * (e.g., headers, footers, navbars) across multiple pages.
+ *
+ * @param {string} [basePath="../components"]
+ *        The relative path from this script to the shared components' directory.
+ * @returns {Promise<void>}
+ *        Resolves when all components have been loaded and injected.
+ */
+async function loadComponents(basePath = "../shared/components") {
+    const elements = document.querySelectorAll("div[id]");
+
+    for (const el of elements) {
+        const id = el.id;
+        const folderPath = `${basePath}/${id}`;
+        const htmlPath = `${folderPath}/${id}.html`;
+        const cssPath = `${folderPath}/${id}.css`;
+        const jsPath = `${folderPath}/${id}.js`;
+
+        try {
+            const htmlResponse = await fetch(htmlPath);
+            if (!htmlResponse.ok) {
+                console.warn(`Missing HTML for component: ${id}`);
+                continue;
+            }
+
+            el.innerHTML = await htmlResponse.text();
+
+            const cssResponse = await fetch(cssPath);
+            if (cssResponse.ok && !document.querySelector(`link[href="${cssPath}"]`)) {
+                const link = document.createElement("link");
+                link.rel = "stylesheet";
+                link.href = cssPath;
+                document.head.appendChild(link);
+                console.log(`Loaded CSS for ${id}`);
+            }
+
+            const jsResponse = await fetch(jsPath);
+            if (jsResponse.ok && !document.querySelector(`script[src="${jsPath}"]`)) {
+                const script = document.createElement("script");
+                script.src = jsPath;
+
+                script.onload = () => {
+                    const initFunctionName = `init_${id}`;
+
+                    if (typeof window[initFunctionName] === "function") {
+                        window[initFunctionName]();
+                    }
+                };
+
+                document.body.appendChild(script);
+                console.log(`Loaded JS for ${id}`);
+            }
+
+            console.log(`Loaded component: ${id}`);
+        } catch (err) {
+            console.error(`Failed to load component: ${id}`, err);
+        }
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => loadComponents());

--- a/features/talent/index.html
+++ b/features/talent/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+
+    <!-- Import the component injector -->
+    <script src="../shared/scripts/injector.js" defer></script>
+</head>
+<body>
+    <!--
+        Placeholder for a shared component.
+
+        The injector works as follows:
+        1. It looks for all <div> elements with an `id`.
+        2. If a folder exists under the `../shared/components/` directory that matches the `id`,
+           it treats it as a component.
+        3. It injects {id}.html into the div, and optionally adds {id}.css and {id}.js.
+        Example:
+        <div id="header"></div> → looks for ../shared/components/header/header.html
+    -->
+    <div id="header"></div>
+</body>
+</html>


### PR DESCRIPTION
### Summary
Adds a component injector that dynamically loads shared HTML components (with optional CSS/JS) based on <div id="..."> placeholders. This reduces repetitive copy-pasting and simplifies updates across pages.

### Creating a Component
Each component is stored in its own folder under `features/shared/components/` with files named after the component ID.

Example: creating a "header" component:
```
features/shared/components/header/
├─ header.html <!-- HTML markup for the header -->
├─ header.css <!-- optional CSS for styling -->
└─ header.js <!-- optional JS for behavior -->
```

Example `header.html`
```html
<header>
    <h1>My Website</h1>
    <nav>...</nav>
</header>
```

Example `header.js`
```js
function init_header() {
    console.log("Header initialized");
}
```

### Applying a Component
In any page, add a `<div>` with the component ID and call the injector:
```html
<body>
    <div id="header"></div>

    <script src="../shared/scripts/injector.js"></script>
</body>
```

The injector will:
1. Inject `header.html` into `<div id="header">`
2. Load `header.css` into `<head>` (if exists)
3. Load `header.js` into `<body>` (if exists)